### PR TITLE
Make saveCalibrationFile yamls compatible with C++ CameraInfoManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,35 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(camera_info_manager_py)
 
-find_package(catkin REQUIRED COMPONENTS camera_info_manager roscpp rospy sensor_msgs)
+find_package(catkin REQUIRED COMPONENTS rospy sensor_msgs)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 catkin_python_setup()
 catkin_package(CATKIN_DEPENDS sensor_msgs)
 
-add_executable(generate_camera_info
-  tests/generate_camera_info.cpp
-  )
-target_link_libraries(generate_camera_info ${catkin_LIBRARIES})
-
 # Unit test uses nose, but needs rostest to create a ROS environment.
 if (CATKIN_ENABLE_TESTING)
+  find_package(roscpp REQUIRED)
+  find_package(camera_info_manager REQUIRED)
+  add_executable(generate_camera_info
+    tests/generate_camera_info.cpp
+    )
+  # TODO(lucasw) Can the roscpp and camera_info_manager dependencies
+  # get added to catkin_LIBRARIES somehow?
+  target_link_libraries(generate_camera_info ${catkin_LIBRARIES}
+      ${roscpp_LIBRARIES} ${camera_info_manager_LIBRARIES})
+
+  # Run generate_camera_info with env ROS_HOME set to pwd
+  # or if not pwd somewhere else where the load_cpp_camera_info.py
+  # will be able to find it (TODO(lucasw)).
+  add_custom_command(OUTPUT camera_info/camera.yaml
+                     COMMAND ROS_HOME=`pwd` generate_camera_info
+                     DEPENDS generate_camera_info)
+
   find_package(rostest REQUIRED)
+
+  # TODO(lucasw) I want to have the rostest generate camera.yaml,
+  # this does not.
+  add_rostest(tests/load_cpp_camera_info.test DEPENDS camera_info/camera.yaml)
   add_rostest(tests/unit_test.test)
 endif(CATKIN_ENABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,16 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(camera_info_manager_py)
 
-find_package(catkin REQUIRED COMPONENTS rospy sensor_msgs)
+find_package(catkin REQUIRED COMPONENTS camera_info_manager roscpp rospy sensor_msgs)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 catkin_python_setup()
 catkin_package(CATKIN_DEPENDS sensor_msgs)
+
+add_executable(generate_camera_info
+  tests/generate_camera_info.cpp
+  )
+target_link_libraries(generate_camera_info ${catkin_LIBRARIES})
 
 # Unit test uses nose, but needs rostest to create a ROS environment.
 if (CATKIN_ENABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,18 +19,8 @@ if (CATKIN_ENABLE_TESTING)
   target_link_libraries(generate_camera_info ${catkin_LIBRARIES}
       ${roscpp_LIBRARIES} ${camera_info_manager_LIBRARIES})
 
-  # Run generate_camera_info with env ROS_HOME set to pwd
-  # or if not pwd somewhere else where the load_cpp_camera_info.py
-  # will be able to find it (TODO(lucasw)).
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/camera_info/camera.yaml
-                    COMMAND ROS_HOME=${CMAKE_CURRENT_BINARY_DIR} rosrun camera_info_manager_py generate_camera_info
-                    DEPENDS generate_camera_info)
-
   find_package(rostest REQUIRED)
 
-  add_custom_target(camera_yaml DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/camera_info/camera.yaml)
-  # TODO(lucasw) I want to have the rostest generate camera.yaml,
-  # this does not.
-  add_rostest(tests/load_cpp_camera_info.test DEPENDENCIES camera_yaml)
+  add_rostest(tests/load_cpp_camera_info.test DEPENDENCIES generate_camera_info)
   add_rostest(tests/unit_test.test)
 endif(CATKIN_ENABLE_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,14 +22,15 @@ if (CATKIN_ENABLE_TESTING)
   # Run generate_camera_info with env ROS_HOME set to pwd
   # or if not pwd somewhere else where the load_cpp_camera_info.py
   # will be able to find it (TODO(lucasw)).
-  add_custom_command(OUTPUT camera_info/camera.yaml
-                     COMMAND ROS_HOME=`pwd` generate_camera_info
-                     DEPENDS generate_camera_info)
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/camera_info/camera.yaml
+                    COMMAND ROS_HOME=${CMAKE_CURRENT_BINARY_DIR} rosrun camera_info_manager_py generate_camera_info
+                    DEPENDS generate_camera_info)
 
   find_package(rostest REQUIRED)
 
+  add_custom_target(camera_yaml DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/camera_info/camera.yaml)
   # TODO(lucasw) I want to have the rostest generate camera.yaml,
   # this does not.
-  add_rostest(tests/load_cpp_camera_info.test DEPENDS camera_info/camera.yaml)
+  add_rostest(tests/load_cpp_camera_info.test DEPENDENCIES camera_yaml)
   add_rostest(tests/unit_test.test)
 endif(CATKIN_ENABLE_TESTING)

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>camera_info_manager</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>rostest</build_depend>
   <build_depend>sensor_msgs</build_depend>

--- a/src/camera_info_manager/camera_info_manager.py
+++ b/src/camera_info_manager/camera_info_manager.py
@@ -646,13 +646,13 @@ def saveCalibrationFile(ci, filename, cname):
              'image_height': ci.height,
              'camera_name': cname,
              'distortion_model': ci.distortion_model,
-             'distortion_coefficients': {'data': ci.D},
-             'camera_matrix': {'data': ci.K},
-             'rectification_matrix': {'data': ci.R},
-             'projection_matrix': {'data': ci.P}}
+             'distortion_coefficients': {'data': ci.D, 'rows': 1, 'cols': len(ci.D)},
+             'camera_matrix': {'data': ci.K, 'rows': 3, 'cols': 3},
+             'rectification_matrix': {'data': ci.R, 'rows': 3, 'cols': 3},
+             'projection_matrix': {'data': ci.P, 'rows': 3, 'cols': 4}}
 
     try:
-        rc = yaml.dump(calib, f)
+        rc = yaml.safe_dump(calib, f)
         return True
 
     except IOError:

--- a/tests/generate_camera_info.cpp
+++ b/tests/generate_camera_info.cpp
@@ -1,0 +1,42 @@
+/**
+  Example of saving and loading a camera_info yaml using the C++ camera_info_manager
+*/
+
+#include <camera_info_manager/camera_info_manager.h>
+#include <ros/ros.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/SetCameraInfo.h>
+
+// The saving of calibration files is private, this is how
+// that is bypassed.
+// (from https://github.com/ros-industrial/human_tracker/blob/master/packages/camera_info_manager/tests/unit_test.cpp )
+// issue SetCameraInfo service request
+void set_calibration(ros::NodeHandle node,
+                     const sensor_msgs::CameraInfo &calib)
+{
+  ros::ServiceClient client =
+    node.serviceClient<sensor_msgs::SetCameraInfo>("set_camera_info");
+  sensor_msgs::SetCameraInfo set_camera_info;
+  set_camera_info.request.camera_info = calib;
+  client.call(set_camera_info);
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "generate_camera_info");
+  ros::NodeHandle nh;
+  camera_info_manager::CameraInfoManager cim(nh);
+  sensor_msgs::CameraInfo camera_info;
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  // cim.saveCalibrationFile(camera_info, "cpp_cim_test.yaml", "camera");
+  set_calibration(nh, camera_info);
+
+  std::string url;
+  ros::param::get("~url", url);
+  cim.validateURL(url);
+  cim.loadCameraInfo(url);
+  // cim.saveCalibrationFile("cpp_cim_test2.yaml");
+}

--- a/tests/generate_camera_info.cpp
+++ b/tests/generate_camera_info.cpp
@@ -15,7 +15,7 @@ void set_calibration(ros::NodeHandle node,
                      const sensor_msgs::CameraInfo &calib)
 {
   ros::ServiceClient client =
-    node.serviceClient<sensor_msgs::SetCameraInfo>("set_camera_info");
+      node.serviceClient<sensor_msgs::SetCameraInfo>("set_camera_info");
   sensor_msgs::SetCameraInfo set_camera_info;
   set_camera_info.request.camera_info = calib;
   client.call(set_camera_info);
@@ -26,17 +26,23 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "generate_camera_info");
   ros::NodeHandle nh;
   camera_info_manager::CameraInfoManager cim(nh);
-  sensor_msgs::CameraInfo camera_info;
 
-  ros::AsyncSpinner spinner(1);
-  spinner.start();
-
+  ros::spin();
+  // Can't call this private function
   // cim.saveCalibrationFile(camera_info, "cpp_cim_test.yaml", "camera");
-  set_calibration(nh, camera_info);
+  // this works but this node needs to just provide the service
+  if (false)
+  {
+    ros::AsyncSpinner spinner(1);
+    spinner.start();
 
-  std::string url;
-  ros::param::get("~url", url);
-  cim.validateURL(url);
-  cim.loadCameraInfo(url);
-  // cim.saveCalibrationFile("cpp_cim_test2.yaml");
+    sensor_msgs::CameraInfo camera_info;
+    set_calibration(nh, camera_info);
+
+    std::string url;
+    ros::param::get("~url", url);
+    cim.validateURL(url);
+    cim.loadCameraInfo(url);
+    // cim.saveCalibrationFile("cpp_cim_test2.yaml");
+  }
 }

--- a/tests/generate_camera_info.py
+++ b/tests/generate_camera_info.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import rospy
+import camera_info_manager
+import yaml
+
+from sensor_msgs.msg import CameraInfo
+# from sensor_msgs.srv import SetCameraInfo()
+
+rospy.init_node("generate_camera_info_py")
+ci = CameraInfo()
+cname = "camera"
+camera_info_manager.saveCalibrationFile(ci, "camera_info_manager_py.yaml", cname)
+
+with open("camera_info_manager_py_yaml_dump.yaml", 'w') as f:
+    calib = {'image_width': ci.width,
+             'image_height': ci.height,
+             'camera_name': cname,
+             'distortion_model': ci.distortion_model,
+             'distortion_coefficients': {'data': ci.D, 'rows': 1, 'cols': len(ci.D)},
+             'camera_matrix': {'data': ci.K, 'rows': 3, 'cols': 3},
+             'rectification_matrix': {'data': ci.R, 'rows': 3, 'cols': 3},
+             'projection_matrix': {'data': ci.P, 'rows': 3, 'cols': 4}}
+
+    rc = yaml.dump(calib, f)
+    f.close()

--- a/tests/load_cpp_camera_info.test
+++ b/tests/load_cpp_camera_info.test
@@ -8,6 +8,11 @@
 
 <launch>
 
+  <node name="camera_info_cpp" pkg="camera_info_manager_py" type="generate_camera_info" >
+    <!-- put the yaml somewhere other than .ros/camera_info? -->
+    <!-- env name="ROS_HOME" value="" /-->
+  </node>
+
   <!-- start test_camera_info_manager Python node -->
   <test pkg="camera_info_manager_py" type="test_load_cpp_camera_info.py"
         name="test_load_cpp_camera_info"

--- a/tests/load_cpp_camera_info.test
+++ b/tests/load_cpp_camera_info.test
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!-- rostest launch file for camera_info_manager_py
+
+     This unit test uses rostest, because the CameraInfoManager class
+     constructor requires a ROS environment.  Otherwise, it is
+     completely self-contained.  
+-->
+
+<launch>
+
+  <!-- start test_camera_info_manager Python node -->
+  <test pkg="camera_info_manager_py" type="test_load_cpp_camera_info.py"
+        name="test_load_cpp_camera_info"
+        test-name="test_load_cpp_camera_info" time-limit="5.0" />
+
+</launch>

--- a/tests/test_load_cpp_camera_info.py
+++ b/tests/test_load_cpp_camera_info.py
@@ -12,6 +12,8 @@ class TestLoadCppCameraInfo(unittest.TestCase):
         # generated, then check values against expected.
         # The values ought to be passed as args into both this test and the C++
         # camera info generation.
+        ci = loadCalibrationFile("camera_info/camera.yaml", "camera")
+        print ci
         self.assertTrue(True)
 
 if __name__ == '__main__':

--- a/tests/test_load_cpp_camera_info.py
+++ b/tests/test_load_cpp_camera_info.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import unittest
+
+from camera_info_manager import *
+
+
+class TestLoadCppCameraInfo(unittest.TestCase):
+
+    def test_load_cpp_camera_info(self):
+        # TODO(lucasw) load the camera.yaml that the C++ camera_info_manager
+        # generated, then check values against expected.
+        # The values ought to be passed as args into both this test and the C++
+        # camera info generation.
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    rospy.init_node('test_load_cpp_camera_info')
+    import rostest
+    rostest.rosrun('camera_info_manager_py', 'test_load_cpp_camera_info', TestLoadCppCameraInfo)

--- a/tests/test_load_cpp_camera_info.py
+++ b/tests/test_load_cpp_camera_info.py
@@ -3,18 +3,31 @@
 import unittest
 
 from camera_info_manager import *
-
+from sensor_msgs.srv import SetCameraInfo
 
 class TestLoadCppCameraInfo(unittest.TestCase):
 
     def test_load_cpp_camera_info(self):
+        rospy.wait_for_service('set_camera_info')
+        set_camera_info = rospy.ServiceProxy('set_camera_info', SetCameraInfo)
+        camera_info = CameraInfo()
+        camera_info.width = 123
+        camera_info.height = 456
+        try:
+            resp1 = set_camera_info(camera_info)
+        except rospy.ServiceException as exc:
+            rospy.logerr("service did not process request" + str(exc))
+            self.assertTrue(False)
+            return
+
+        self.assertTrue(resp1.success)
+
         # TODO(lucasw) load the camera.yaml that the C++ camera_info_manager
         # generated, then check values against expected.
         # The values ought to be passed as args into both this test and the C++
         # camera info generation.
-        ci = loadCalibrationFile("camera_info/camera.yaml", "camera")
-        print ci
-        self.assertTrue(True)
+        loaded_camera_info = loadCalibrationFile("camera_info/camera.yaml", "camera")
+        self.assertEquals(camera_info, loaded_camera_info)
 
 if __name__ == '__main__':
     rospy.init_node('test_load_cpp_camera_info')


### PR DESCRIPTION
For #7 

My C++ camera info generator could be made into an actual test, right now it is a matter of running that manually, and running the python equivalent manually.