### PR TITLE
Optionally depend on python3 version of packages for noetic

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
 
   <name>camera_info_manager_py</name>
   <version>0.2.3</version>
@@ -22,10 +22,12 @@
   <build_depend>rostest</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
-  <run_depend>python-rospkg</run_depend>
-  <run_depend>python-yaml</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>sensor_msgs</run_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
 
   <test_depend>rosunit</test_depend>
 


### PR DESCRIPTION
Probably this works in melodic (I could make a github action to do melodic and noetic), but there could be a noetic-devel branch created for this (and the earlier version could be called kinetic-devel in case anyone comes looking for that).

Without sepcifying python3-rospkg having this package in a workspace and then doing a rosdep install results in this:

```
Package python-rospkg is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python3-rospkg
...
ERROR: the following rosdeps failed to install
executing command [sudo -H apt-get install -y ros-noetic-roslint]
  apt: command [sudo -H apt-get install -y python-rospkg] failed
```