### PR TITLE
python3 support  for noetic

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
 
   <name>camera_info_manager_py</name>
   <version>0.2.3</version>
@@ -22,10 +22,12 @@
   <build_depend>rostest</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
-  <run_depend>python-rospkg</run_depend>
-  <run_depend>python-yaml</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>sensor_msgs</run_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
 
   <test_depend>rosunit</test_depend>
 

--- a/tests/test_camera_info_manager.py
+++ b/tests/test_camera_info_manager.py
@@ -101,7 +101,7 @@ def set_calibration(calib):
         proxy = rospy.ServiceProxy('set_camera_info', SetCameraInfo)
         rsp = proxy(calib)
         return rsp
-    except rospy.ServiceException, e:
+    except rospy.ServiceException as e:
         print("Service call failed: " + str(e))
         return None
 


### PR DESCRIPTION
in addition to #14 , 

Fix python3 syntax error
```
SyntaxError: invalid syntax                                                                       
[Testcase: testtest_camera_info_manager_py] ... FAILURE!                                          
FAILURE: False is not true : test [test_camera_info_manager_py] did not generate test results     
  File "/usr/lib/python3.8/unittest/case.py", line 60, in testPartExecutor                        
    yield                                                                                         
  File "/usr/lib/python3.8/unittest/case.py", line 676, in run                                    
    self._callTestMethod(testMethod)                                                              
  File "/usr/lib/python3.8/unittest/case.py", line 633, in _callTestMethod                        
    method()                                                                                      
  File "/opt/ros/noetic/lib/python3/dist-packages/rostest/runner.py", line 164, in fn             
    self.assert_(os.path.isfile(test_file), "test [%s] did not generate test results"%test_name)  
  File "/usr/lib/python3.8/unittest/case.py", line 1410, in deprecated_func                       
    return original_func(*args, **kwargs)                                                         
  File "/usr/lib/python3.8/unittest/case.py", line 765, in assertTrue                             
    raise self.failureException(msg)                                                              --------------------------------------------------------------------------------                  
                                                                                                  [ROSTEST]-----------------------------------------------------------------------                  
                                                                                                  
[testtest_camera_info_manager_py][failed]                                                                                                                                                           
SUMMARY                                                                                            * RESULT: FAIL                                                                                   
 * TESTS: 0                                                                                       
 * ERRORS: 0                                                                                       * FAILURES: 1  
 * ```